### PR TITLE
Badger db memory

### DIFF
--- a/RELEASELOG.md
+++ b/RELEASELOG.md
@@ -1,6 +1,9 @@
 # gome-schedule Release Log
 
-### 1.0.0
+### Merged & not released
+- Add: badger DB memory settings for small memory footprints
+
+### 1.0.0 - untagged
 * initial release
 
 ### 1.0.1

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -17,6 +17,7 @@ type Conf struct {
 	CoreServicePort  string
 	GenerateSpec     bool
 	StateTimeSec     int64 //time to check device schedule state in seconds
+	FullMemory	     bool	//use this for full in memory badgerDB cache
 }
 
 var App *Conf
@@ -47,6 +48,7 @@ func configDefaults(c *Conf) {
 	c.CoreServicePort = "6660"
 	c.GenerateSpec = false
 	c.StateTimeSec = 30
+	c.FullMemory = false
 	return
 }
 
@@ -61,6 +63,7 @@ func configFlags(c *Conf) {
 	flag.StringVar(&c.CoreServicePort, "corePort", c.CoreServicePort, "tcp port for gome-core")
 	flag.BoolVar(&c.GenerateSpec, "generateSpec", c.GenerateSpec, "print the http spec to console")
 	flag.Int64Var(&c.StateTimeSec, "stateTimeSec", c.StateTimeSec, "tine to check device states")
+	flag.BoolVar(&c.FullMemory, "fullMemory", c.FullMemory, "run database with full memory cache mem > 1GB required")
 	flag.Parse()
 	return
 }

--- a/database/database.go
+++ b/database/database.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"github.com/dgraph-io/badger"
+	"github.com/rebelit/gome-schedule/common/config"
 	"github.com/rebelit/gome-schedule/common/stat"
 	"log"
 )
@@ -29,7 +30,39 @@ func Open(path string) (Database, error) {
 	}
 
 	d := Badger{}
-	opts := badger.DefaultOptions(path)
+	opts := badger.Options{}
+	if config.App.FullMemory {
+		opts = badger.DefaultOptions(path)
+	} else {
+		opts = badger.Options{
+			Dir:                     path,
+			ValueDir:                path,
+			SyncWrites:              true,
+			TableLoadingMode:        0,
+			ValueLogLoadingMode:     0,
+			LevelOneSize:            256 << 20,
+			LevelSizeMultiplier:     10,
+			NumVersionsToKeep:       1,
+			ReadOnly:                false,
+			Truncate:                false,
+			Logger:                  nil,
+			EventLogging:            true,
+			MaxTableSize:            64 << 20,
+			MaxLevels:               7,
+			ValueThreshold:          32,
+			NumMemtables:            5,
+			NumLevelZeroTables:      5,
+			NumLevelZeroTablesStall: 10,
+			ValueLogFileSize:        1<<30 - 1,
+			ValueLogMaxEntries:      1000,
+			NumCompactors:           2,
+			CompactL0OnClose:        true,
+			LogRotatesToFlush:       2,
+			VerifyValueChecksum:     false,
+			BypassLockGuard:         false,
+		}
+	}
+
 	db, err := badger.Open(opts)
 	if err != nil {
 		log.Printf("ERROR: database %s open %s", path, err)


### PR DESCRIPTION
changes the default startup of badgerDB to use file vs. in mem caching and the total memory allocated to badger.  This is for systems like a raspberry pi that don't have 2GB of RAM. 

flag `-fullMemory` can be used if you want full in mem cache and max performance.